### PR TITLE
:wrench: Leverage libhal-armcortex profiles

### DIFF
--- a/conan/profiles/lpc40
+++ b/conan/profiles/lpc40
@@ -1,16 +1,3 @@
-[settings]
-compiler=gcc
-compiler.cppstd=20
-compiler.libcxx=libstdc++
-compiler.version=12.2
-os=baremetal
-arch=thumbv7em
-arch.float_abi={{ float_abi }}
-arch.processor={{ cpu }}
-
-[tool_requires]
-arm-gnu-toolchain/12.2.1
-
 [options]
 *:platform={{ platform }}
 

--- a/conan/profiles/lpc4072
+++ b/conan/profiles/lpc4072
@@ -1,4 +1,3 @@
-{% set cpu = "cortex-m4" %}
-{% set float_abi = "soft" %}
+{% include "cortex-m4" %}
 {% set platform = "lpc4072" %}
 {% include "lpc40" %}

--- a/conan/profiles/lpc4074
+++ b/conan/profiles/lpc4074
@@ -1,4 +1,3 @@
-{% set cpu = "cortex-m4" %}
-{% set float_abi = "soft" %}
+{% include "cortex-m4" %}
 {% set platform = "lpc4074" %}
 {% include "lpc40" %}

--- a/conan/profiles/lpc4076
+++ b/conan/profiles/lpc4076
@@ -1,4 +1,3 @@
-{% set cpu = "cortex-m4" %}
-{% set float_abi = "hard" %}
+{% include "cortex-m4f" %}
 {% set platform = "lpc4076" %}
 {% include "lpc40" %}

--- a/conan/profiles/lpc4078
+++ b/conan/profiles/lpc4078
@@ -1,4 +1,3 @@
-{% set cpu = "cortex-m4" %}
-{% set float_abi = "hard" %}
+{% include "cortex-m4f" %}
 {% set platform = "lpc4078" %}
 {% include "lpc40" %}

--- a/conan/profiles/lpc4088
+++ b/conan/profiles/lpc4088
@@ -1,4 +1,3 @@
-{% set cpu = "cortex-m4" %}
-{% set float_abi = "hard" %}
+{% include "cortex-m4f" %}
 {% set platform = "lpc4088" %}
 {% include "lpc40" %}


### PR DESCRIPTION
Include cortex-m4 and cortex-m4f profiles in the lpc40 profiles. These profiles include the necessary compiler flags for lpc40 targets. libhal-armcortex's recipe is removing the compiler flags from the recipe as they are not propagated to all packages in an application.