### PR TITLE
:bug: Fix FPU initialization for hard float demos

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -96,7 +96,8 @@ class libhal_lpc40_conan(ConanFile):
         self.requires("libhal/[^2.0.0]")
         self.requires("libhal-util/[^2.0.0]")
         self.requires("ring-span-lite/[^0.6.0]")
-        self.requires("libhal-armcortex/[^2.0.0]")
+        self.requires(
+            "libhal-armcortex/[^2.0.0-alpha.1, include_prerelease=True]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def layout(self):

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -38,7 +38,7 @@ class demos(ConanFile):
         self.tool_requires("cmake-arm-embedded/1.0.0")
 
     def requirements(self):
-        self.requires("libhal-lpc40/2.0.0")
+        self.requires("libhal-lpc40/[^2.0.0-alpha.1, include_prerelease=True]")
         self.requires("libhal-util/[^2.0.0]")
 
     def build(self):

--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -33,7 +33,11 @@ int main()
 {
   hal::cortex_m::initialize_data_section();
 
-  hal::cortex_m::try_initialize_floating_point_unit();
+// GCC provides the __ARM_FP Macros to indicate if float-abi is set to
+// "hard" or "softfp" and not defined if set to "soft"
+#if defined(__ARM_FP)
+  hal::cortex_m::initialize_floating_point_unit();
+#endif
 
   auto is_finished = application();
 

--- a/src/uart_reg.hpp
+++ b/src/uart_reg.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 
 #include <libhal-util/bit.hpp>


### PR DESCRIPTION
Use the __ARM_FP macro to call as the
`hal::cortex_m::try_initialize_floating_point_unit()` function is actually unreliable due to the fact that vendor supplied floating point IP blocks do not require bits to be set in that field. Meaning that the function does not do as it is advertised.

NOTE: Deleted 2.0.0 version from package repo and moving version back to 2.0.0-alpha.1. This way we have an alpha release of 2.0.0 before doing a full 2.0.0 release.

Resolves #174
Resolves #171