### PR TITLE
:technologist: Add debug info to all builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(libhal-lpc40
 
 target_include_directories(libhal-lpc40 PUBLIC include)
 target_compile_features(libhal-lpc40 PRIVATE cxx_std_20)
+target_compile_options(libhal-lpc40 PRIVATE -g)
 target_link_libraries(libhal-lpc40 PRIVATE
   libhal::libhal
   libhal::util

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.0.0-alpha.1"
+    version = "2.0.0-alpha.2"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"
@@ -97,7 +97,7 @@ class libhal_lpc40_conan(ConanFile):
         self.requires("libhal-util/[^2.0.0]")
         self.requires("ring-span-lite/[^0.6.0]")
         self.requires(
-            "libhal-armcortex/[2.0.0-alpha.1, include_prerelease=True]")
+            "libhal-armcortex/[2.0.0-alpha.2, include_prerelease=True]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def layout(self):

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(libhal-lpc40 REQUIRED CONFIG)
 set(DEMOS adc blinker can gpio i2c interrupt_pin uart pwm)
 
 add_library(startup_code main.cpp)
-
+target_compile_options(startup_code PRIVATE -g)
 target_link_libraries(startup_code PRIVATE libhal::lpc40)
 
 foreach(demo IN LISTS DEMOS)
@@ -35,6 +35,7 @@ foreach(demo IN LISTS DEMOS)
     add_executable(${current_project} applications/${demo}.cpp)
 
     target_compile_features(${current_project} PRIVATE cxx_std_20)
+    target_compile_options(${current_project} PRIVATE -g)
     target_link_libraries(${current_project} PRIVATE startup_code libhal::lpc40)
 
     # # NOTE: Uncomment the section below to enable printf support

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -38,7 +38,7 @@ class demos(ConanFile):
         self.tool_requires("cmake-arm-embedded/1.0.0")
 
     def requirements(self):
-        self.requires("libhal-lpc40/[~2.0.0-alpha.1, include_prerelease=True]")
+        self.requires("libhal-lpc40/2.0.0-alpha.2")
         self.requires("libhal-util/[^2.0.0]")
 
     def build(self):


### PR DESCRIPTION
CMake only adds the `-g` debug info flag for the "Debug" build type. This makes sense for libraries deployed on a server or computer but not an embedded system. The elf file is not what is executed but the .bin or .hex file generated from it. Those generated files have all extra debug info eliminated. Because of this, each build type can have debug information without degrading performance or increasing code size. The benefit is that users can use an on chip debugger and step into this libraries APIs to inspect possible issues or hidden registers.