### PR TITLE
:bug: Fix segfault when uart receives data

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.0.0-alpha.2"
+    version = "2.0.0-alpha.3"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"

--- a/demos/applications/uart.cpp
+++ b/demos/applications/uart.cpp
@@ -26,13 +26,13 @@ hal::status application()
   using namespace hal::literals;
   // Change the input frequency to match the frequency of the crystal attached
   // to the external OSC pins.
-  hal::lpc40::clock::maximum(12.0_MHz);
+  hal::lpc40::clock::maximum(10.0_MHz);
 
   auto& clock = hal::lpc40::clock::get();
   const auto cpu_frequency = clock.get_frequency(hal::lpc40::peripheral::cpu);
   hal::cortex_m::dwt_counter counter(cpu_frequency);
 
-  std::array<hal::byte, 512> receive_buffer;
+  std::array<hal::byte, 512> receive_buffer{};
   auto uart0 = HAL_CHECK(hal::lpc40::uart::get(0,
                                                receive_buffer,
                                                {

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -38,7 +38,7 @@ class demos(ConanFile):
         self.tool_requires("cmake-arm-embedded/1.0.0")
 
     def requirements(self):
-        self.requires("libhal-lpc40/2.0.0-alpha.2")
+        self.requires("libhal-lpc40/2.0.0-alpha.3")
         self.requires("libhal-util/[^2.0.0]")
 
     def build(self):

--- a/include/libhal-lpc40/uart.hpp
+++ b/include/libhal-lpc40/uart.hpp
@@ -67,6 +67,11 @@ public:
     std::span<hal::byte> p_receive_working_buffer,
     serial::settings p_settings = {});
 
+  uart(uart& p_other) = delete;
+  uart& operator=(uart& p_other) = delete;
+  uart(uart&& p_other);
+  uart& operator=(uart&& p_other);
+
 private:
   explicit uart(const port& p_port, std::span<hal::byte> p_receive_buffer);
 

--- a/src/uart.cpp
+++ b/src/uart.cpp
@@ -308,6 +308,24 @@ uart::uart(const port& p_port, std::span<hal::byte> p_receive_buffer)
 {
 }
 
+uart::uart(uart&& p_other)
+  : m_port(p_other.m_port)
+  , m_receive_buffer(std::move(p_other.m_receive_buffer))
+{
+  // Setup receive interrupt again to relocate the handler to the new location
+  setup_receive_interrupt();
+}
+
+uart& uart::operator=(uart&& p_other)
+{
+  m_port = p_other.m_port;
+  m_receive_buffer = std::move(p_other.m_receive_buffer);
+  // Setup receive interrupt again to relocate the handler to the new location
+  setup_receive_interrupt();
+
+  return *this;
+}
+
 bool finished_sending(uart_reg_t* p_reg)
 {
   return bit::extract<bit::mask::from<5U>()>(p_reg->line_status);


### PR DESCRIPTION
The interrupt handler uses a pointer to the original object, captured by a lambda. When the object is moved, the address is no longer valid. The interrupt handler setup must be called again in the move constructor to relocate the address to the new moved address.

Resolves #179