### PR TITLE
:zap: Improve unit test build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@ find_package(libhal-util REQUIRED CONFIG)
 find_package(libhal-armcortex REQUIRED CONFIG)
 find_package(ring-span-lite REQUIRED CONFIG)
 
-if(NOT BUILD_TESTING STREQUAL OFF)
-  add_subdirectory(tests)
-endif()
-
 add_library(libhal-lpc40
   src/power.cpp
   src/clock.cpp
@@ -41,11 +37,15 @@ add_library(libhal-lpc40
 target_include_directories(libhal-lpc40 PUBLIC include)
 target_compile_features(libhal-lpc40 PRIVATE cxx_std_20)
 target_compile_options(libhal-lpc40 PRIVATE -g)
-target_link_libraries(libhal-lpc40 PRIVATE
+target_link_libraries(libhal-lpc40 PUBLIC
   libhal::libhal
   libhal::util
   libhal::armcortex
   nonstd::ring-span-lite
 )
+
+if(NOT BUILD_TESTING STREQUAL OFF)
+  add_subdirectory(tests)
+endif()
 
 install(TARGETS libhal-lpc40)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,10 +40,6 @@ else()
 endif()
 
 find_package(ut REQUIRED CONFIG)
-find_package(libhal REQUIRED CONFIG)
-find_package(libhal-util REQUIRED CONFIG)
-find_package(libhal-armcortex REQUIRED CONFIG)
-find_package(ring-span-lite REQUIRED CONFIG)
 
 add_executable(unit_test
   adc.test.cpp
@@ -55,18 +51,6 @@ add_executable(unit_test
   i2c.test.cpp
   pwm.test.cpp
   main.test.cpp
-
-  ../src/power.cpp
-  ../src/clock.cpp
-  ../src/can.cpp
-  ../src/pin.cpp
-  ../src/pwm.cpp
-  ../src/input_pin.cpp
-  ../src/output_pin.cpp
-  ../src/i2c.cpp
-  ../src/uart.cpp
-  ../src/interrupt_pin.cpp
-  ../src/adc.cpp
 )
 
 target_include_directories(unit_test PUBLIC . ../include ../src)
@@ -93,7 +77,4 @@ target_link_options(unit_test PRIVATE
 
 target_link_libraries(unit_test PRIVATE
   boost-ext-ut::ut
-  libhal::libhal
-  libhal::util
-  libhal::armcortex
-  nonstd::ring-span-lite)
+  libhal-lpc40)


### PR DESCRIPTION
Previously the unit tests built every source file in parallel with the main library building each source file. To prevent double building, unit test's CMakeLists.txt file now links against the libhal-lpc40 library.