### PR TITLE
:construction_worker: Reduce # of prebuilt binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,37 +14,16 @@ jobs:
     uses: libhal/ci/.github/workflows/library.yml@3.0.2
     secrets: inherit
 
-  lpc4072:
+  cortex-m4:
     uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.2
     with:
-      profile: lpc4072
+      profile: cortex-m4
       processor_profile: https://github.com/libhal/libhal-armcortex.git
     secrets: inherit
 
-  lpc4074:
+  cortex-m4f:
     uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.2
     with:
-      profile: lpc4074
-      processor_profile: https://github.com/libhal/libhal-armcortex.git
-    secrets: inherit
-
-  lpc4076:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.2
-    with:
-      profile: lpc4076
-      processor_profile: https://github.com/libhal/libhal-armcortex.git
-    secrets: inherit
-
-  lpc4078:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.2
-    with:
-      profile: lpc4078
-      processor_profile: https://github.com/libhal/libhal-armcortex.git
-    secrets: inherit
-
-  lpc4088:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.2
-    with:
-      profile: lpc4088
+      profile: cortex-m4f
       processor_profile: https://github.com/libhal/libhal-armcortex.git
     secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,18 +39,15 @@ class libhal_lpc40_conan(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps", "VirtualBuildEnv"
 
     options = {
-        "platform": [
-            "lpc4072",
-            "lpc4074",
-            "lpc4076",
-            "lpc4078",
-            "lpc4088",
-            "ANY"
-        ],
+        "platform": ["ANY"],
     }
     default_options = {
         "platform": "ANY",
     }
+
+    def package_id(self):
+        if self.info.options.get_safe("platform"):
+            del self.info.options.platform
 
     @property
     def _use_linker_script(self):


### PR DESCRIPTION
Using cortex-m4 and cortex-m4f as the profiles rather than the chip's profile name. This reduces the prebuilt count from 6 to 2. There were only two versions of the prebuilt binaries and having additional profiles wastes space.