### PR TITLE
:bug: Fix i2c last byte read problem

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.0.4"
+    version = "2.0.5"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -141,8 +141,8 @@ void i2c::interrupt()
       if (m_read_iterator != m_read_end) {
         *m_read_iterator++ = static_cast<hal::byte>(data);
       }
-      // Check if the position has been pushed past the buffer length
-      if (m_read_iterator + 1 == m_read_end) {
+      // Check if the buffer has been exhausted
+      if (m_read_iterator == m_read_end) {
         clear_mask = i2c_control::assert_acknowledge;
         transaction_finished = true;
       } else {


### PR DESCRIPTION
lpc40::i2c::driver_transaction returns early during a read transaction. The i2c interrupt continues to fire and fills the buffer after the function has returned. This is problematic because it requires a delay on the driver's part to manage this. The memory of the buffer may also no longer be valid by the time the interrupt fires again.