### PR TITLE
Fix I2C premature busy state bug

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.0.4"
+    version = "2.0.5"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -137,20 +137,20 @@ void i2c::interrupt()
       set_mask = i2c_control::stop;
       break;
     }
-    case i2c_host_state::received_data_received_ack: {
+    case i2c_host_state::received_data_transmitted_ack: {
       if (m_read_iterator != m_read_end) {
         *m_read_iterator++ = static_cast<hal::byte>(data);
       }
-      // Check if the position has been pushed past the buffer length
+      // Check if the buffer has been exhausted
       if (m_read_iterator + 1 == m_read_end) {
+        // Next state will be `received_data_transmitted_nack`
         clear_mask = i2c_control::assert_acknowledge;
-        transaction_finished = true;
       } else {
         set_mask = i2c_control::assert_acknowledge;
       }
       break;
     }
-    case i2c_host_state::received_data_received_nack: {
+    case i2c_host_state::received_data_transmitted_nack: {
       transaction_finished = true;
       if (m_read_iterator != m_read_end) {
         *m_read_iterator++ = static_cast<hal::byte>(data);

--- a/src/i2c_reg.hpp
+++ b/src/i2c_reg.hpp
@@ -80,8 +80,8 @@ enum class i2c_host_state : std::uint32_t
   arbitration_lost = 0x38,
   peripheral_address_read_sent_received_ack = 0x40,
   peripheral_address_read_sent_received_nack = 0x48,
-  received_data_received_ack = 0x50,
-  received_data_received_nack = 0x58,
+  received_data_transmitted_ack = 0x50,
+  received_data_transmitted_nack = 0x58,
   own_address_received = 0xA0,
   do_nothing = 0xF8
 };


### PR DESCRIPTION
- Fix bug that caused `driver_transaction` to return early due to a prematurely entering `m_busy` state.
- Renamed `received_data_received_(n)ack` states to `received_data_transmitted_(n)ack`