### PR TITLE
:construction_worker: Remove "release" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,4 @@ jobs:
       profile: lpc4088
       processor_profile: https://github.com/libhal/libhal-armcortex.git
     secrets: inherit
-
-  release:
-    needs: [ci, lpc4072, lpc4074, lpc4076, lpc4078, lpc4088]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true
+  


### PR DESCRIPTION
Releases trigger package uploads, so creating a release is redundant.