### PR TITLE
:zap: Optimize demo build size

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -35,7 +35,12 @@ foreach(demo IN LISTS DEMOS)
     add_executable(${current_project} applications/${demo}.cpp)
 
     target_compile_features(${current_project} PRIVATE cxx_std_20)
+
+    target_link_options(${current_project} PRIVATE -Wl,--wrap=malloc
+        -Wl,--wrap=free -Wl,--wrap=_malloc_r
+        -Wl,--wrap=_free_r -lnosys)
     target_link_libraries(${current_project} PRIVATE startup_code libhal::lpc40)
 
     libhal_post_build(${current_project})
+    libhal_disassemble(${current_project})
 endforeach()

--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -53,7 +53,7 @@ int main()
 namespace boost {
 void throw_exception(std::exception const& e)
 {
-  std::abort();
+  hal::halt();
 }
 }  // namespace boost
 
@@ -91,11 +91,6 @@ extern "C"
     return length;
   }
 
-  int ead([[maybe_unused]] FILE* file, [[maybe_unused]] char* ptr, int length)
-  {
-    return length;
-  }
-
   // Dummy implementation of _lseek
   int _lseek([[maybe_unused]] int file,
              [[maybe_unused]] int ptr,
@@ -127,5 +122,26 @@ extern "C"
   void* _sbrk([[maybe_unused]] int size)
   {
     return nullptr;
+  }
+
+  void* __wrap_malloc([[maybe_unused]] size_t p_length)
+  {
+    return nullptr;
+  }
+
+  void __wrap_free([[maybe_unused]] void* ptr, [[maybe_unused]] size_t length)
+  {
+    return;
+  }
+
+  void* __wrap__malloc_r([[maybe_unused]] size_t p_length)
+  {
+    return nullptr;
+  }
+
+  void __wrap__free_r([[maybe_unused]] void* ptr,
+                      [[maybe_unused]] size_t length)
+  {
+    return;
   }
 }


### PR DESCRIPTION
Wrap malloc, free and their reentrent variants with empty functions to reduce code size. These functions are unused in the code base but due to the GCC ABI for virtual destructors and potentially due to Boost.LEAF introducing std::exception into the code base, these functions have been linked in.