### PR TITLE
:bug: Fix missing spi header

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.1.2"
+    version = "2.1.3"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -39,7 +39,7 @@ class demos(ConanFile):
         self.tool_requires("libhal-cmake-util/1.0.0")
 
     def requirements(self):
-        self.requires("libhal-lpc40/2.1.2")
+        self.requires("libhal-lpc40/2.1.3")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
spi header is missing in 2.1.2, so bumping the version so the next version to capture the spi header.