### PR TITLE
:art: Use cmake-util helper functions

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.1.3"
+    version = "2.1.4"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"
@@ -80,7 +80,7 @@ class libhal_lpc40_conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
-        self.tool_requires("libhal-cmake-util/1.1.0")
+        self.tool_requires("libhal-cmake-util/2.1.0")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -14,32 +14,23 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-# Set project name to demos
-project(demos VERSION 0.0.1 LANGUAGES CXX)
+project(demos LANGUAGES CXX)
 
-# Import the libhal-lpc40 library/package (and all of its dependencies)
-find_package(libhal-lpc40 REQUIRED CONFIG)
+libhal_build_demos(
+  DEMOS
+  adc
+  blinker
+  can
+  gpio
+  i2c
+  interrupt_pin
+  uart
+  pwm
+  spi
 
-# List of demo applications
-# To add a new demo to the list, simply add its filename without the .cpp
-# extension to this list.
-set(DEMOS adc blinker can gpio i2c interrupt_pin uart pwm spi)
+  PACKAGES
+  libhal-lpc40
 
-add_library(startup_code main.cpp)
-target_compile_options(startup_code PRIVATE -g)
-target_link_libraries(startup_code PRIVATE libhal::lpc40)
-
-foreach(demo IN LISTS DEMOS)
-    set(current_project ${demo}.elf)
-    message(STATUS "Generating Demo for \"${current_project}\"")
-    add_executable(${current_project} applications/${demo}.cpp)
-
-    target_compile_features(${current_project} PRIVATE cxx_std_20)
-    target_compile_options(${current_project} PRIVATE -g)
-    target_link_options(${current_project} PRIVATE
-        --oslib=semihost --crt0=minimal)
-    target_link_libraries(${current_project} PRIVATE startup_code libhal::lpc40)
-
-    libhal_post_build(${current_project})
-    libhal_disassemble(${current_project})
-endforeach()
+  LINK_LIBRARIES
+  libhal::lpc40
+)

--- a/demos/applications/pwm.cpp
+++ b/demos/applications/pwm.cpp
@@ -32,15 +32,16 @@ hal::status application()
   while (true) {
     HAL_CHECK(pwm.frequency(1.0_kHz));
 
-    for (float duty_cycle = 0.0f; duty_cycle < 1.01f; duty_cycle += 0.05f) {
+    for (unsigned iteration = 0; iteration <= 100; iteration += 1) {
+      auto duty_cycle = static_cast<float>(iteration) / 100.0f;
       HAL_CHECK(pwm.duty_cycle(duty_cycle));
       hal::delay(clock, 100ms);
     }
 
     HAL_CHECK(pwm.duty_cycle(0.5f));
 
-    for (hal::hertz frequency = 100.0_Hz; frequency < 500.0_kHz;
-         frequency *= 5.0f) {
+    for (unsigned iteration = 0; iteration < 100; iteration++) {
+      auto frequency = 100.0_Hz * (static_cast<float>(iteration) * 10);
       HAL_CHECK(pwm.frequency(frequency));
       hal::delay(clock, 100ms);
     }

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -30,16 +30,14 @@ class demos(ConanFile):
         cmake_layout(self, build_folder=platform_directory)
 
     def validate(self):
-        if self.settings.os != "baremetal":
-            raise ConanInvalidConfiguration(
-                f"Only baremetal OS is allowed here!")
+        pass
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
-        self.tool_requires("libhal-cmake-util/1.0.0")
+        self.tool_requires("libhal-cmake-util/2.1.0")
 
     def requirements(self):
-        self.requires("libhal-lpc40/2.1.3")
+        self.requires("libhal-lpc40/2.1.4")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -34,7 +34,7 @@ int main()
 }
 
 namespace boost {
-void throw_exception(std::exception const& e)
+void throw_exception(std::exception const&)
 {
   hal::halt();
 }

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -279,8 +279,8 @@ status i2c::driver_configure(const settings& p_settings)
     .resistor(pin_resistor::none)
     .open_drain(true);
 
-  using high_t = std::remove_volatile<decltype(reg->duty_cycle_high)>::type;
-  using low_t = std::remove_volatile<decltype(reg->duty_cycle_low)>::type;
+  using high_t = std::remove_volatile_t<decltype(reg->duty_cycle_high)>;
+  using low_t = std::remove_volatile_t<decltype(reg->duty_cycle_low)>;
 
   reg->duty_cycle_high = static_cast<high_t>(high_side_clocks);
   reg->duty_cycle_low = static_cast<low_t>(low_side_clocks);

--- a/src/input_pin.cpp
+++ b/src/input_pin.cpp
@@ -34,7 +34,7 @@ result<input_pin> input_pin::get(std::uint8_t p_port,
   return gpio;
 }
 
-input_pin::input_pin(std::uint8_t p_port, std::uint8_t p_pin)
+input_pin::input_pin(std::uint8_t p_port, std::uint8_t p_pin)  // NOLINT
   : m_port(p_port)
   , m_pin(p_pin)
 {

--- a/src/interrupt_pin.cpp
+++ b/src/interrupt_pin.cpp
@@ -99,7 +99,7 @@ interrupt_pin& interrupt_pin::operator=(interrupt_pin&& p_other) noexcept
   return *this;
 }
 
-interrupt_pin::interrupt_pin(std::uint8_t p_port, std::uint8_t p_pin)
+interrupt_pin::interrupt_pin(std::uint8_t p_port, std::uint8_t p_pin)  // NOLINT
   : m_port(p_port)
   , m_pin(p_pin)
 {

--- a/src/output_pin.cpp
+++ b/src/output_pin.cpp
@@ -31,7 +31,7 @@ result<output_pin> output_pin::get(std::uint8_t p_port,
   return gpio;
 }
 
-output_pin::output_pin(std::uint8_t p_port, std::uint8_t p_pin)
+output_pin::output_pin(std::uint8_t p_port, std::uint8_t p_pin)  // NOLINT
   : m_port(p_port)
   , m_pin(p_pin)
 {

--- a/src/pwm.cpp
+++ b/src/pwm.cpp
@@ -139,7 +139,8 @@ pwm::pwm(channel p_channel)
 {
 }
 
-result<pwm> pwm::get(std::uint8_t p_peripheral, std::uint8_t p_channel)
+result<pwm> pwm::get(std::uint8_t p_peripheral,  // NOLINT
+                     std::uint8_t p_channel)     // NOLINT
 {
   if (p_peripheral > 1) {
     // "LPC40 series microcontrollers only have PWM0 and PWM1."

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(${PROJECT_NAME} main.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC .)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-if(BAREMETAL)
+if(${CMAKE_CROSSCOMPILING})
   target_link_options(${PROJECT_NAME} PRIVATE --oslib=semihost)
 endif()
 


### PR DESCRIPTION
- Simplifies building libhal libraries and packages
- By using the standard cmake utilities, upgrades are easily installed by bumping the libhal-cmake-util version number
- Utilizes clang-tidy
- Bump version to 2.1.4