### PR TITLE
:mute: Remove log from demo

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -16,8 +16,6 @@ cmake_minimum_required(VERSION 3.20)
 
 project(demos LANGUAGES CXX)
 
-message(WARNING "LIBHAL_PLATFORM = ${LIBHAL_PLATFORM}")
-
 libhal_build_demos(
   DEMOS
   adc


### PR DESCRIPTION
This same log will appear from libhal-cmake-util/4.0.2 so no need to have it here.