### PR TITLE
:technologist: libhal-armcortex/3.0.1

### DIFF
--- a/.github/workflows/3.0.1.yml
+++ b/.github/workflows/3.0.1.yml
@@ -1,0 +1,11 @@
+name: 🚀 Release 3.0.1
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-version.yml
+    with:
+      version: 3.0.1
+    secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,7 +35,7 @@ class libhal_lpc40_conan(ConanFile):
               "lpc4074", "lpc4078", "lpc4088")
     settings = "compiler", "build_type", "os", "arch"
 
-    python_requires = "libhal-bootstrap/[^0.0.2]"
+    python_requires = "libhal-bootstrap/[^0.0.6]"
     python_requires_extend = "libhal-bootstrap.library"
 
     options = {
@@ -54,7 +54,7 @@ class libhal_lpc40_conan(ConanFile):
                 self.options.platform == "lpc4072")
 
     def requirements(self):
-        self.requires("libhal-armcortex/[^3.0.0]", transitive_headers=True)
+        self.requires("libhal-armcortex/[^3.0.1]", transitive_headers=True)
         self.requires("ring-span-lite/[^0.6.0]")
 
     def package_info(self):

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -31,9 +31,7 @@ libhal_build_demos(
 
   PACKAGES
   libhal-lpc40
-  libhal-exceptions
 
   LINK_LIBRARIES
   libhal::lpc40
-  libhal::exceptions
 )

--- a/demos/applications/gpio.cpp
+++ b/demos/applications/gpio.cpp
@@ -17,7 +17,6 @@
 #include <libhal-lpc40/constants.hpp>
 #include <libhal-lpc40/input_pin.hpp>
 #include <libhal-lpc40/output_pin.hpp>
-#include <libhal-util/serial.hpp>
 #include <libhal-util/steady_clock.hpp>
 
 void application()

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -25,4 +25,3 @@ class demos(ConanFile):
         bootstrap = self.python_requires["libhal-bootstrap"]
         bootstrap.module.add_demo_requirements(self, is_platform=True)
         self.requires("libhal-lpc40/[>=3.0.0]")
-        self.requires("libhal-exceptions/[^0.0.1]")

--- a/include/libhal-lpc40/spi.hpp
+++ b/include/libhal-lpc40/spi.hpp
@@ -48,14 +48,16 @@ public:
   /**
    * @brief Construct a new spi object
    *
-   * @param p_bus
-   * @param p_settings
+   * @param p_bus - bus number to use
+   * @param p_settings - spi settings to achieve
+   * @throws hal::operation_not_supported - if the p_bus is not 0, 1, or 2 or if
+   * the spi settings could not be achieved.
    */
   spi(std::uint8_t p_bus, const spi::settings& p_settings = {});
   /**
-   * @brief Construct a new spi object
+   * @brief Construct a new spi object using bus info directly
    *
-   * @param p_bus
+   * @param p_bus - Full bus information
    */
   spi(bus_info p_bus);
 

--- a/src/spi.cpp
+++ b/src/spi.cpp
@@ -82,7 +82,7 @@ spi::spi(std::uint8_t p_bus_number, const spi::settings& p_settings)
     };
   } else {
     // "Supported spi busses are 0, 1, and 2!";
-    hal::safe_throw(std::errc::invalid_argument);
+    hal::safe_throw(hal::operation_not_supported(this));
   }
 
   spi::driver_configure(p_settings);

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -19,7 +19,7 @@ from conan import ConanFile
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    python_requires = "libhal-bootstrap/[^0.0.2]"
+    python_requires = "libhal-bootstrap/[^0.0.6]"
     python_requires_extend = "libhal-bootstrap.library_test_package"
 
     def requirements(self):

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -17,12 +17,13 @@
 #include <libhal-lpc40/input_pin.hpp>
 
 volatile bool run = false;
+bool pin_level = false;
 
 int main()
 {
   if (run) {
     auto input_pin = hal::lpc40::input_pin(2, 0);
-    printf("level (%d, %d) = %d\n", 2, 0, input_pin.level());
+    pin_level = input_pin.level();
   }
   return 0;
 }


### PR DESCRIPTION
This version of `libhal-armcortex` will automatically bring in
libhal-exceptions and picolibc so the end developer does not have to
link such packages into their build systems directly.