### PR TITLE
:arrow_up: libhal-armcortex/3.0.2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,7 +35,7 @@ class libhal_lpc40_conan(ConanFile):
               "lpc4074", "lpc4078", "lpc4088")
     settings = "compiler", "build_type", "os", "arch"
 
-    python_requires = "libhal-bootstrap/[^0.0.6]"
+    python_requires = "libhal-bootstrap/[^1.0.0]"
     python_requires_extend = "libhal-bootstrap.library"
 
     options = {
@@ -54,7 +54,7 @@ class libhal_lpc40_conan(ConanFile):
                 self.options.platform == "lpc4072")
 
     def requirements(self):
-        self.requires("libhal-armcortex/[^3.0.1]", transitive_headers=True)
+        self.requires("libhal-armcortex/[^3.0.2]", transitive_headers=True)
         self.requires("ring-span-lite/[^0.6.0]")
 
     def package_info(self):

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -18,7 +18,7 @@ from conan import ConanFile
 
 
 class demos(ConanFile):
-    python_requires = "libhal-bootstrap/[^0.0.2]"
+    python_requires = "libhal-bootstrap/[^1.0.0]"
     python_requires_extend = "libhal-bootstrap.demo"
 
     def requirements(self):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -19,7 +19,7 @@ from conan import ConanFile
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    python_requires = "libhal-bootstrap/[^0.0.6]"
+    python_requires = "libhal-bootstrap/[^1.0.0]"
     python_requires_extend = "libhal-bootstrap.library_test_package"
 
     def requirements(self):


### PR DESCRIPTION
Upgrades the version of libhal-exceptions to 1.0.0 which will fix the linking errors by including the whole archive file in the symbol table resolution.