### PR TITLE
:bug: Fix logic for can baud rate configuration

### DIFF
--- a/.github/workflows/3.0.4.yml
+++ b/.github/workflows/3.0.4.yml
@@ -1,0 +1,11 @@
+name: 🚀 Release 3.0.4
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-version.yml
+    with:
+      version: 3.0.4
+    secrets: inherit

--- a/src/can.cpp
+++ b/src/can.cpp
@@ -156,11 +156,8 @@ void can::configure_baud_rate(const can::port& p_port,
   bool baud_rate_above_100khz = p_settings.baud_rate > 100.0_kHz;
   auto baud_rate_prescalar = hal::is_valid(p_settings, frequency);
 
-  bool valid_configuration = external_oscillator_used &&
-                             baud_rate_above_100khz &&
-                             baud_rate_prescalar.has_value();
-
-  if (valid_configuration) {
+  if ((baud_rate_above_100khz && not external_oscillator_used) ||
+      not baud_rate_prescalar.has_value()) {
     safe_throw(hal::operation_not_supported(this));
   }
 


### PR DESCRIPTION
Previous implementation threw an exception when the baud rate configuration was valid. The expression for evaluating that the baud rate was valid was also not valid based on how the CAN peripheral works. The driver must check that the pre-scalar is valid but also check that if the baud rate is set to above 100kHz then we must ensure that the external oscillator is used.