### PR TITLE
🩹 Make all drivers 'final'

### DIFF
--- a/include/libhal-lpc40/adc.hpp
+++ b/include/libhal-lpc40/adc.hpp
@@ -20,7 +20,6 @@
 #include <libhal/initializers.hpp>
 #include <libhal/units.hpp>
 
-#include "constants.hpp"
 #include "pin.hpp"
 
 namespace hal::lpc40 {
@@ -28,17 +27,12 @@ namespace hal::lpc40 {
  * @brief Analog to digital converter
  *
  */
-class adc : public hal::adc
+class adc final : public hal::adc
 {
 public:
-  static constexpr std::intptr_t lpc_apb0_base = 0x40000000UL;
-  static constexpr std::intptr_t lpc_adc_addr = lpc_apb0_base + 0x34000;
-
   /// Channel specific information
   struct channel
   {
-    // Pointer to the peripheral memory map
-    std::intptr_t reg = lpc_adc_addr;
     /// Default and highest sampling rate is 1 MHz. Careful as changing this for
     /// one channel changes this for all channels on the lpc40xx mcu.
     hertz clock_rate = 1'000'000.0f;
@@ -49,25 +43,6 @@ public:
     /// Pin mux function code
     uint8_t pin_function;
   };
-
-  /**
-   * @brief Construct a custom adc object based on the passed in channel
-   * information.
-   *
-   * Care should be taken to ensure that the adc's operating frequency does not
-   * go above 1MHz and that the the channel index is within the bounds of 0
-   * to 7. Exceeding these bounds will result in a call to std::abort.
-   *
-   * Care should also be taken to ensure that two adc's constructed via this
-   * method do not overlap in index.
-   *
-   * The operating frequency is shared across all adc channels, which means that
-   * the last adc to be constructed will set sampling frequency for all
-   * channels.
-   *
-   * @param p_channel - Which adc channel to use
-   */
-  adc(const channel& p_channel);
 
   /**
    * @brief Get a predefined adc channel
@@ -89,6 +64,25 @@ public:
     static_assert(0 <= p_channel() && p_channel() <= 7,
                   "Available ADC channels are from 0 to 7");
   }
+
+  /**
+   * @brief Construct a custom adc object based on the passed in channel
+   * information.
+   *
+   * Care should be taken to ensure that the adc's operating frequency does not
+   * go above 1MHz and that the the channel index is within the bounds of 0
+   * to 7. Exceeding these bounds will result in a call to std::abort.
+   *
+   * Care should also be taken to ensure that two adc's constructed via this
+   * method do not overlap in index.
+   *
+   * The operating frequency is shared across all adc channels, which means that
+   * the last adc to be constructed will set sampling frequency for all
+   * channels.
+   *
+   * @param p_channel - Which adc channel to use
+   */
+  adc(const channel& p_channel);
 
   adc(adc& p_other) = delete;
   adc& operator=(adc& p_other) = delete;

--- a/include/libhal-lpc40/i2c.hpp
+++ b/include/libhal-lpc40/i2c.hpp
@@ -14,10 +14,8 @@
 
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <span>
-#include <system_error>
 
 #include <libhal/i2c.hpp>
 
@@ -25,7 +23,7 @@
 #include "pin.hpp"
 
 namespace hal::lpc40 {
-class i2c : public hal::i2c
+class i2c final : public hal::i2c
 {
 public:
   using write_iterator = std::span<const hal::byte>::iterator;

--- a/include/libhal-lpc40/input_pin.hpp
+++ b/include/libhal-lpc40/input_pin.hpp
@@ -23,7 +23,7 @@ namespace hal::lpc40 {
  * @brief Input pin implementation for the lpc40xx
  *
  */
-class input_pin : public hal::input_pin
+class input_pin final : public hal::input_pin
 {
 public:
   /**

--- a/include/libhal-lpc40/interrupt_pin.hpp
+++ b/include/libhal-lpc40/interrupt_pin.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <array>
-#include <bit>
 #include <cstdint>
 
 #include <libhal/interrupt_pin.hpp>
@@ -25,7 +23,7 @@ namespace hal::lpc40 {
  * @brief Interrupt pin implementation for the lpc40xx
  *
  */
-class interrupt_pin : public hal::interrupt_pin
+class interrupt_pin final : public hal::interrupt_pin
 {
 public:
   /**

--- a/include/libhal-lpc40/output_pin.hpp
+++ b/include/libhal-lpc40/output_pin.hpp
@@ -23,7 +23,7 @@ namespace hal::lpc40 {
  * @brief Output pin implementation for the lpc40xx
  *
  */
-class output_pin : public hal::output_pin
+class output_pin final : public hal::output_pin
 {
 public:
   /**

--- a/include/libhal-lpc40/pwm.hpp
+++ b/include/libhal-lpc40/pwm.hpp
@@ -34,7 +34,7 @@ namespace hal::lpc40 {
  * channels within the peripheral block.
  *
  */
-class pwm : public hal::pwm
+class pwm final : public hal::pwm
 {
 public:
   /// Channel specific information

--- a/include/libhal-lpc40/spi.hpp
+++ b/include/libhal-lpc40/spi.hpp
@@ -23,7 +23,7 @@
 #include "pin.hpp"
 
 namespace hal::lpc40 {
-class spi : public hal::spi
+class spi final : public hal::spi
 {
 public:
   /// Information used to configure the spi bus

--- a/include/libhal-lpc40/stream_dac.hpp
+++ b/include/libhal-lpc40/stream_dac.hpp
@@ -4,7 +4,7 @@
 #include <libhal/stream_dac.hpp>
 
 namespace hal::lpc40 {
-class stream_dac_u16 : public hal::stream_dac_u16
+class stream_dac_u16 final : public hal::stream_dac_u16
 {
 public:
   stream_dac_u16(hal::io_waiter& p_waiter);
@@ -15,7 +15,7 @@ private:
   hal::io_waiter* m_waiter;
 };
 
-class stream_dac_u8 : public hal::stream_dac_u8
+class stream_dac_u8 final : public hal::stream_dac_u8
 {
 public:
   stream_dac_u8(hal::io_waiter& p_waiter);

--- a/include/libhal-lpc40/uart.hpp
+++ b/include/libhal-lpc40/uart.hpp
@@ -29,7 +29,7 @@ namespace hal::lpc40 {
  * frequency / 48. Otherwise this peripheral cannot guarantee proper
  * transmission or receive of bytes.
  */
-class uart : public hal::serial
+class uart final : public hal::serial
 {
 public:
   /// Port contains all of the information that the lpc40 uart port needs to

--- a/src/adc.cpp
+++ b/src/adc.cpp
@@ -26,17 +26,6 @@
 namespace hal::lpc40 {
 
 namespace {
-/**
- * @brief Convert channel info void pointer to an adc register map type
- *
- * @param p_pointer - pointer to the start
- * @return adc_reg_t*
- */
-adc_reg_t* to_reg_map(std::intptr_t p_pointer)
-{
-  return reinterpret_cast<adc_reg_t*>(p_pointer);  // NOLINT
-}
-
 void setup(const adc::channel& p_channel)
 {
   using namespace hal::literals;
@@ -61,24 +50,22 @@ void setup(const adc::channel& p_channel)
   const auto clock_divider = clock_frequency / p_channel.clock_rate;
   const auto clock_divider_int = static_cast<std::uint32_t>(clock_divider);
 
-  auto* reg = to_reg_map(p_channel.reg);
-
   // Activate burst mode (continuous sampling), power on ADC and set clock
   // divider.
-  hal::bit_modify(reg->control)
+  hal::bit_modify(adc_reg->control)
     .set<adc_control_register::burst_enable>()
     .set<adc_control_register::power_enable>()
     .insert<adc_control_register::clock_divider>(clock_divider_int);
 
   // Enable channel. Must be done in a separate write to memory than power on
   // and burst enable.
-  hal::bit_modify(reg->control)
+  hal::bit_modify(adc_reg->control)
     .set(bit_mask{ .position = p_channel.index, .width = 1 });
 }
 }  // namespace
 
 adc::adc(const channel& p_channel)
-  : m_sample(&to_reg_map(p_channel.reg)->data[p_channel.index])
+  : m_sample(&adc_reg->data[p_channel.index])
 {
   setup(p_channel);
 }

--- a/src/adc_reg.hpp
+++ b/src/adc_reg.hpp
@@ -88,4 +88,8 @@ static constexpr auto overrun = hal::bit_mask::from<30>();
 /// Indicates when the ADC conversion is complete.
 static constexpr auto done = hal::bit_mask::from<31>();
 };  // namespace adc_data_register
+
+constexpr std::intptr_t lpc_apb0_base = 0x40000000UL;
+constexpr std::intptr_t lpc_adc_addr = lpc_apb0_base + 0x34000;
+inline auto* adc_reg = reinterpret_cast<adc_reg_t*>(lpc_adc_addr);
 }  // namespace hal::lpc40

--- a/src/uart_clock.hpp
+++ b/src/uart_clock.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <array>
-#include <cmath>
 #include <cstdint>
 #include <limits>
 


### PR DESCRIPTION
This closes a potential situation where a change to a driver breaks downstream code. By making this final, it cannot be inherited. 