### PR TITLE
:boom: Upgrade to libhal-armcortex/5.0.0

### DIFF
--- a/.github/workflows/5.0.0.yml
+++ b/.github/workflows/5.0.0.yml
@@ -1,0 +1,11 @@
+name: 🚀 Release 5.0.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-version.yml
+    with:
+      version: 5.0.0
+    secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ libhal_test_and_make_library(
   src/i2c.cpp
   src/uart.cpp
   src/interrupt_pin.cpp
+  src/interrupt.cpp
   src/adc.cpp
   src/spi.cpp
   src/dma.cpp

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,7 +55,7 @@ class libhal_lpc40_conan(ConanFile):
             self,
             override_libhal_util_version="5.0.1",
             override_libhal_version="4.2.0")
-        self.requires("libhal-armcortex/[^4.0.0]", transitive_headers=True)
+        self.requires("libhal-armcortex/[^5.0.0]", transitive_headers=True)
         self.requires("ring-span-lite/[^0.7.0]", transitive_headers=True)
 
     def add_linker_scripts_to_link_flags(self):

--- a/demos/applications/stream_dac.cpp
+++ b/demos/applications/stream_dac.cpp
@@ -25,61 +25,16 @@
 
 #include "resources/uniq-BOMBORA.u8.pcm.h"
 
-void hard_fault()
-{
-  while (true) {
-    continue;
-  }
-}
-
-void bus_fault()
-{
-  while (true) {
-    continue;
-  }
-}
-
-void usage_fault()
-{
-  while (true) {
-    continue;
-  }
-}
-
 std::array<std::uint8_t, 128> samples{};
-
-class do_nothing_io_waiter : public hal::io_waiter
-{
-public:
-  do_nothing_io_waiter() = default;
-
-private:
-  void driver_wait() override
-  {
-  }
-
-  void driver_resume() noexcept override
-  {
-  }
-};
 
 void application()
 {
-  hal::cortex_m::interrupt::initialize<hal::value(hal::lpc40::irq::max)>();
-  hal::cortex_m::interrupt(hal::value(hal::cortex_m::irq::hard_fault))
-    .enable(hard_fault);
-  hal::cortex_m::interrupt(hal::value(hal::cortex_m::irq::usage_fault))
-    .enable(usage_fault);
-  hal::cortex_m::interrupt(hal::value(hal::cortex_m::irq::bus_fault))
-    .enable(bus_fault);
-
-  do_nothing_io_waiter waiter;
-  hal::lpc40::stream_dac_u8 dac(waiter);
+  hal::lpc40::stream_dac_u8 dac;
 
   while (true) {
     // Change to 8'000.0f for LOFI
     dac.write({
-      .sample_rate = 13'500.0f,
+      .sample_rate = 16'000.0f,
       .data = uniq_BOMBORA_u8_pcm,
     });
   }

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -24,5 +24,5 @@ class demos(ConanFile):
     def requirements(self):
         bootstrap = self.python_requires["libhal-bootstrap"]
         bootstrap.module.add_demo_requirements(self, is_platform=True)
-        self.requires("libhal-lpc40/[^4.0.0 || latest]")
+        self.requires("libhal-lpc40/[^5.0.0 || latest]")
         self.requires("minimp3/cci.20211201")

--- a/include/libhal-lpc40/can.hpp
+++ b/include/libhal-lpc40/can.hpp
@@ -56,7 +56,7 @@ public:
   can& operator=(can const& p_other) = delete;
   can(can&& p_other) noexcept = delete;
   can& operator=(can&& p_other) noexcept = delete;
-  ~can();
+  virtual ~can();
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/include/libhal-lpc40/constants.hpp
+++ b/include/libhal-lpc40/constants.hpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include <libhal-armcortex/interrupt.hpp>
+
 /**
  * @brief libhal drivers for the lpc40 series of microcontrollers from NXP
  *
@@ -61,100 +63,94 @@ enum class peripheral : std::uint8_t
 };
 
 /// List of interrupt request numbers for this platform
-enum class irq : std::uint16_t
+enum class irq : cortex_m::irq_t
 {
   /// Watchdog Timer Interrupt
-  wdt = 16 + 0,
+  wdt = 0,
   /// Timer0 Interrupt
-  timer0 = 16 + 1,
+  timer0 = 1,
   /// Timer1 Interrupt
-  timer1 = 16 + 2,
+  timer1 = 2,
   /// Timer2 Interrupt
-  timer2 = 16 + 3,
+  timer2 = 3,
   /// Timer3 Interrupt
-  timer3 = 16 + 4,
+  timer3 = 4,
   /// UART0 Interrupt
-  uart0 = 16 + 5,
+  uart0 = 5,
   /// UART1 Interrupt
-  uart1 = 16 + 6,
+  uart1 = 6,
   /// UART2 Interrupt
-  uart2 = 16 + 7,
+  uart2 = 7,
   /// UART3 Interrupt
-  uart3 = 16 + 8,
+  uart3 = 8,
   /// PWM1 Interrupt
-  pwm1 = 16 + 9,
+  pwm1 = 9,
   /// I2C0 Interrupt
-  i2c0 = 16 + 10,
+  i2c0 = 10,
   /// I2C1 Interrupt
-  i2c1 = 16 + 11,
+  i2c1 = 11,
   /// I2C2 Interrupt
-  i2c2 = 16 + 12,
+  i2c2 = 12,
   /// Reserved
-  reserved0 = 16 + 13,
+  reserved0 = 13,
   /// SSP0 Interrupt
-  ssp0 = 16 + 14,
+  ssp0 = 14,
   /// SSP1 Interrupt
-  ssp1 = 16 + 15,
+  ssp1 = 15,
   /// PLL0 Lock (Main PLL) Interrupt
-  pll0 = 16 + 16,
+  pll0 = 16,
   /// Real Time Clock Interrupt
-  rtc = 16 + 17,
+  rtc = 17,
   /// External Interrupt 0 Interrupt
-  eint0 = 16 + 18,
+  eint0 = 18,
   /// External Interrupt 1 Interrupt
-  eint1 = 16 + 19,
+  eint1 = 19,
   /// External Interrupt 2 Interrupt
-  eint2 = 16 + 20,
+  eint2 = 20,
   /// External Interrupt 3 Interrupt
-  eint3 = 16 + 21,
+  eint3 = 21,
   /// A/D Converter Interrupt
-  adc = 16 + 22,
+  adc = 22,
   /// Brown-Out Detect Interrupt
-  bod = 16 + 23,
+  bod = 23,
   /// USB Interrupt
-  usb = 16 + 24,
+  usb = 24,
   /// CAN Interrupt
-  can = 16 + 25,
+  can = 25,
   /// General Purpose DMA Interrupt
-  dma = 16 + 26,
+  dma = 26,
   /// I2S Interrupt
-  i2s = 16 + 27,
+  i2s = 27,
   /// Ethernet Interrupt
-  enet = 16 + 28,
+  enet = 28,
   /// SD/MMC card I/F Interrupt
-  mci = 16 + 29,
+  mci = 29,
   /// Motor Control PWM Interrupt
-  mcpwm = 16 + 30,
+  mcpwm = 30,
   /// Quadrature Encoder Interface Interrupt
-  qei = 16 + 31,
+  qei = 31,
   /// PLL1 Lock (USB PLL) Interrupt
-  pll1 = 16 + 32,
+  pll1 = 32,
   /// USB Activity interrupt
-  usbactivity = 16 + 33,
+  usbactivity = 33,
   /// CAN Activity interrupt
-  canactivity = 16 + 34,
+  canactivity = 34,
   /// UART4 Interrupt
-  uart4 = 16 + 35,
+  uart4 = 35,
   /// SSP2 Interrupt
-  ssp2 = 16 + 36,
+  ssp2 = 36,
   /// LCD Interrupt
-  lcd = 16 + 37,
+  lcd = 37,
   /// GPIO Interrupt
-  gpio = 16 + 38,
+  gpio = 38,
   ///  PWM0 Interrupt
-  pwm0 = 16 + 39,
+  pwm0 = 39,
   ///  EEPROM Interrupt
-  eeprom = 16 + 40,
+  eeprom = 40,
   ///  CMP0 Interrupt
-  cmp0 = 16 + 41,
+  cmp0 = 41,
   ///  CMP1 Interrupt
-  cmp1 = 16 + 42,
+  cmp1 = 42,
   max,
-};
-/// Set of lpc40 specific error types
-enum class error_t
-{
-  requires_usage_of_external_oscillator,
-  baud_rate_impossible,
 };
 }  // namespace hal::lpc40

--- a/include/libhal-lpc40/i2c.hpp
+++ b/include/libhal-lpc40/i2c.hpp
@@ -97,7 +97,7 @@ public:
   i2c& operator=(i2c const& p_other) = delete;
   i2c(i2c&& p_other) noexcept = delete;
   i2c& operator=(i2c&& p_other) noexcept = delete;
-  ~i2c();
+  virtual ~i2c();
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/include/libhal-lpc40/input_pin.hpp
+++ b/include/libhal-lpc40/input_pin.hpp
@@ -41,7 +41,7 @@ public:
   input_pin& operator=(input_pin const& p_other) = delete;
   input_pin(input_pin&& p_other) noexcept = delete;
   input_pin& operator=(input_pin&& p_other) noexcept = delete;
-  ~input_pin() = default;
+  virtual ~input_pin() = default;
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/include/libhal-lpc40/interrupt.hpp
+++ b/include/libhal-lpc40/interrupt.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace hal::lpc40 {
+/**
+ * @brief Initialize interrupts for the lpc40 series processors
+ *
+ * Only initializes after the first call. Does nothing afterwards. Can be
+ * called multiple times without issue.
+ *
+ */
+void initialize_interrupts();
+}  // namespace hal::lpc40

--- a/include/libhal-lpc40/interrupt_pin.hpp
+++ b/include/libhal-lpc40/interrupt_pin.hpp
@@ -40,7 +40,7 @@ public:
   interrupt_pin& operator=(interrupt_pin const& p_other) = delete;
   interrupt_pin(interrupt_pin&& p_other) noexcept = delete;
   interrupt_pin& operator=(interrupt_pin&& p_other) noexcept = delete;
-  ~interrupt_pin();
+  virtual ~interrupt_pin();
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/include/libhal-lpc40/output_pin.hpp
+++ b/include/libhal-lpc40/output_pin.hpp
@@ -41,7 +41,7 @@ public:
   output_pin& operator=(output_pin const& p_other) = delete;
   output_pin(output_pin&& p_other) noexcept = delete;
   output_pin& operator=(output_pin&& p_other) noexcept = delete;
-  ~output_pin() = default;
+  virtual ~output_pin() = default;
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/include/libhal-lpc40/pwm.hpp
+++ b/include/libhal-lpc40/pwm.hpp
@@ -63,7 +63,7 @@ public:
   pwm& operator=(pwm const& p_other) = delete;
   pwm(pwm&& p_other) noexcept = delete;
   pwm& operator=(pwm&& p_other) noexcept = delete;
-  ~pwm() = default;
+  virtual ~pwm() = default;
 
 private:
   void driver_frequency(hertz p_frequency) override;

--- a/include/libhal-lpc40/spi.hpp
+++ b/include/libhal-lpc40/spi.hpp
@@ -65,7 +65,7 @@ public:
   spi& operator=(spi const& p_other) = delete;
   spi(spi&& p_other) noexcept = delete;
   spi& operator=(spi&& p_other) noexcept = delete;
-  ~spi();
+  virtual ~spi();
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/include/libhal-lpc40/stream_dac.hpp
+++ b/include/libhal-lpc40/stream_dac.hpp
@@ -4,10 +4,27 @@
 #include <libhal/stream_dac.hpp>
 
 namespace hal::lpc40 {
+/**
+ * @brief 16-bit stream dac implementation
+ *
+ * Operated using DMA. The DMA request number is unique to the dac and thus does
+ * not conflict with any other driver.
+ *
+ * The lpc40 dac only supports up to 10-bit resolution so the 6 least
+ * significant bits will be ignored.
+ *
+ * Note that there is only a single dac on the lpc40 series and thus only one
+ * dac driver should be used in an application.
+ */
 class stream_dac_u16 final : public hal::stream_dac_u16
 {
 public:
-  stream_dac_u16(hal::io_waiter& p_waiter);
+  stream_dac_u16(hal::io_waiter& p_waiter = hal::polling_io_waiter());
+  stream_dac_u16(const stream_dac_u16& p_other) = delete;
+  stream_dac_u16& operator=(const stream_dac_u16& p_other) = delete;
+  stream_dac_u16(stream_dac_u16&& p_other) noexcept = delete;
+  stream_dac_u16& operator=(stream_dac_u16&& p_other) noexcept = delete;
+  virtual ~stream_dac_u16() = default;
 
 private:
   void driver_write(const hal::stream_dac_u16::samples& p_samples) override;
@@ -15,10 +32,29 @@ private:
   hal::io_waiter* m_waiter;
 };
 
+/**
+ * @brief 8-bit stream dac implementation
+ *
+ * Operated using DMA. The DMA request number is unique to the dac and thus does
+ * not conflict with any other driver.
+ *
+ * The lpc40 supports a right-aligned 10-bit resolution dac making it easy to
+ * DMA byte data to it by choosing the 2nd byte in the register. No additional
+ * preprocessing is necessary by the driver to DMA data from a byte stream to
+ * the DAC.
+ *
+ * Note that there is only a single dac on the lpc40 series and thus only one
+ * dac driver should be used in an application.
+ */
 class stream_dac_u8 final : public hal::stream_dac_u8
 {
 public:
-  stream_dac_u8(hal::io_waiter& p_waiter);
+  stream_dac_u8(hal::io_waiter& p_waiter = hal::polling_io_waiter());
+  stream_dac_u8(const stream_dac_u8& p_other) = delete;
+  stream_dac_u8& operator=(const stream_dac_u8& p_other) = delete;
+  stream_dac_u8(stream_dac_u8&& p_other) noexcept = delete;
+  stream_dac_u8& operator=(stream_dac_u8&& p_other) noexcept = delete;
+  virtual ~stream_dac_u8() = default;
 
 private:
   void driver_write(const hal::stream_dac_u8::samples& p_samples) override;

--- a/include/libhal-lpc40/uart.hpp
+++ b/include/libhal-lpc40/uart.hpp
@@ -73,8 +73,9 @@ public:
 
   uart(uart const& p_other) = delete;
   uart& operator=(uart const& p_other) = delete;
-  uart(uart&& p_other) noexcept;
-  uart& operator=(uart&& p_other) noexcept;
+  uart(uart&& p_other) noexcept = delete;
+  uart& operator=(uart&& p_other) noexcept = delete;
+  virtual ~uart() = default;
 
 private:
   void driver_configure(const settings& p_settings) override;

--- a/src/adc.cpp
+++ b/src/adc.cpp
@@ -125,11 +125,11 @@ adc::channel adc::get_predefined_channel_info(std::uint8_t p_channel)
 
 float adc::driver_read()
 {
-  constexpr auto max = bit_limits<12, size_t>::max();
-  constexpr auto max_float = static_cast<float>(max);
+  constexpr auto full_scale_max = bit_limits<12, size_t>::max();
+  constexpr auto full_scale_float = static_cast<float>(full_scale_max);
   // Read sample from peripheral memory
   auto sample_integer = hal::bit_extract<adc_data_register::result>(*m_sample);
   auto sample = static_cast<float>(sample_integer);
-  return sample / max_float;
+  return sample / full_scale_float;
 }
 }  // namespace hal::lpc40

--- a/src/can.cpp
+++ b/src/can.cpp
@@ -17,6 +17,7 @@
 #include <libhal-armcortex/interrupt.hpp>
 #include <libhal-lpc40/clock.hpp>
 #include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/interrupt.hpp>
 #include <libhal-lpc40/pin.hpp>
 #include <libhal-lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
@@ -202,7 +203,7 @@ void can::setup(const can::port& p_port, const can::settings& p_settings)
 {
   auto* reg = get_can_reg(p_port.id);
 
-  cortex_m::interrupt::initialize<value(irq::max)>();
+  initialize_interrupts();
 
   /// Power on CAN BUS peripheral
   power_on(p_port.id);
@@ -333,7 +334,7 @@ void can::driver_on_receive(hal::callback<can::handler> p_receive_handler)
   };
 
   auto can_handler = static_callable<can, 0, void(void)>(isr).get_handler();
-  cortex_m::interrupt(value(irq::can)).enable(can_handler);
+  cortex_m::enable_interrupt(irq::can, can_handler);
 
   bit_modify(reg->IER).set(can_interrupts::received_message);
 }

--- a/src/dma.cpp
+++ b/src/dma.cpp
@@ -7,6 +7,7 @@
 #include <libhal-armcortex/interrupt.hpp>
 #include <libhal-lpc40/constants.hpp>
 #include <libhal-lpc40/dma.hpp>
+#include <libhal-lpc40/interrupt.hpp>
 #include <libhal-lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/enum.hpp>
@@ -81,10 +82,14 @@ std::array<dma_channel*, dma_channel_count> dma_channel_reg{
 };
 
 std::array<hal::callback<void(void)>, dma_channel_count> dma_callbacks{
-  hal::cortex_m::interrupt::nop, hal::cortex_m::interrupt::nop,
-  hal::cortex_m::interrupt::nop, hal::cortex_m::interrupt::nop,
-  hal::cortex_m::interrupt::nop, hal::cortex_m::interrupt::nop,
-  hal::cortex_m::interrupt::nop, hal::cortex_m::interrupt::nop,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
+  hal::cortex_m::default_interrupt_handler,
 };
 
 void handle_dma_interrupt() noexcept
@@ -104,10 +109,9 @@ void handle_dma_interrupt() noexcept
 
 void initialize_dma()
 {
-  hal::lpc40::power_on(hal::lpc40::peripheral::gpdma);
-  hal::cortex_m::interrupt::initialize<hal::value(hal::lpc40::irq::max)>();
-  hal::cortex_m::interrupt(hal::value(hal::lpc40::irq::dma))
-    .enable(handle_dma_interrupt);
+  power_on(peripheral::gpdma);
+  initialize_interrupts();
+  hal::cortex_m::enable_interrupt(irq::dma, handle_dma_interrupt);
   // Enable DMA & use default AHB endianness
   dma_reg->config = 1;
 }

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -19,6 +19,7 @@
 #include <libhal-armcortex/interrupt.hpp>
 #include <libhal-lpc40/clock.hpp>
 #include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/interrupt.hpp>
 #include <libhal-lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/i2c.hpp>
@@ -48,7 +49,7 @@ void disable(i2c::bus_info& p_info)
   reg->control_clear = i2c_control::interface_enable;
 
   // Enable interrupt service routine.
-  cortex_m::interrupt(static_cast<int>(p_info.irq_number)).disable();
+  cortex_m::disable_interrupt(p_info.irq_number);
 }
 
 void i2c::interrupt()
@@ -223,7 +224,7 @@ i2c::i2c(std::uint8_t p_bus_number,
     }
   }
 
-  cortex_m::interrupt::initialize<value(irq::max)>();
+  cortex_m::initialize_interrupts<value(irq::max)>();
   i2c::driver_configure(p_settings);
 }
 
@@ -238,7 +239,7 @@ i2c::i2c(const bus_info& p_bus,
   : m_bus(p_bus)
   , m_waiter(&p_waiter)
 {
-  cortex_m::interrupt::initialize<value(irq::max)>();
+  initialize_interrupts();
   i2c::driver_configure(p_settings);
 }
 
@@ -307,7 +308,7 @@ void i2c::setup_interrupt()
   }
 
   // Enable interrupt service routine.
-  cortex_m::interrupt(hal::value(m_bus.irq_number)).enable(handler);
+  cortex_m::enable_interrupt(m_bus.irq_number, handler);
 }
 
 void i2c::driver_transaction(hal::byte p_address,

--- a/src/interrupt.cpp
+++ b/src/interrupt.cpp
@@ -1,0 +1,9 @@
+#include <libhal-armcortex/interrupt.hpp>
+#include <libhal-lpc40/constants.hpp>
+
+namespace hal::lpc40 {
+void initialize_interrupts()
+{
+  hal::cortex_m::initialize_interrupts<irq::max>();
+}
+}  // namespace hal::lpc40

--- a/src/interrupt_pin.cpp
+++ b/src/interrupt_pin.cpp
@@ -14,10 +14,10 @@
 
 #include <cstdint>
 
-#include <libhal-lpc40/interrupt_pin.hpp>
-
 #include <libhal-armcortex/interrupt.hpp>
 #include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/interrupt.hpp>
+#include <libhal-lpc40/interrupt_pin.hpp>
 #include <libhal-lpc40/pin.hpp>
 #include <libhal-util/enum.hpp>
 
@@ -77,7 +77,7 @@ interrupt_pin::interrupt_pin(std::uint8_t p_port,  // NOLINT
   : m_port(p_port)
   , m_pin(p_pin)
 {
-  cortex_m::interrupt::initialize<value(irq::max)>();
+  initialize_interrupts();
   interrupt_pin::driver_configure(p_settings);
 }
 
@@ -107,7 +107,7 @@ void interrupt_pin::driver_configure(const settings& p_settings)
     .resistor(p_settings.resistor);
 
   // Enable interrupt for gpio and use interrupt handler as our handler.
-  cortex_m::interrupt(value(irq::gpio)).enable(interrupt_pin_handler);
+  cortex_m::enable_interrupt(irq::gpio, interrupt_pin_handler);
 
   if (p_settings.trigger == trigger_edge::both ||
       p_settings.trigger == trigger_edge::rising) {

--- a/src/spi.cpp
+++ b/src/spi.cpp
@@ -16,9 +16,9 @@
 
 #include <libhal-lpc40/spi.hpp>
 
-#include <libhal-armcortex/interrupt.hpp>
 #include <libhal-lpc40/clock.hpp>
 #include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/interrupt.hpp>
 #include <libhal-lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/spi.hpp>

--- a/src/uart.cpp
+++ b/src/uart.cpp
@@ -20,6 +20,7 @@
 #include <libhal-armcortex/interrupt.hpp>
 #include <libhal-lpc40/clock.hpp>
 #include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/interrupt.hpp>
 #include <libhal-lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/enum.hpp>
@@ -164,7 +165,7 @@ void uart::setup_receive_interrupt()
   }
 
   // Enable interrupt service routine.
-  cortex_m::interrupt(value(m_port.irq_number)).enable(handler);
+  cortex_m::enable_interrupt(m_port.irq_number, handler);
 
   // Enable uart interrupt signal
   bit_modify(reg->group2.interrupt_enable)
@@ -239,7 +240,7 @@ uart::uart(std::uint8_t p_port_number,
     hal::safe_throw(hal::operation_not_supported(this));
   }
 
-  cortex_m::interrupt::initialize<value(irq::max)>();
+  initialize_interrupts();
   uart::driver_configure(p_settings);
 }
 
@@ -250,7 +251,7 @@ uart::uart(const uart::port& p_port,
   , m_receive_buffer(p_receive_working_buffer.begin(),
                      p_receive_working_buffer.end())
 {
-  cortex_m::interrupt::initialize<value(irq::max)>();
+  initialize_interrupts();
   uart::driver_configure(p_settings);
 }
 


### PR DESCRIPTION
Upgrading libhal-armcortex, a transitive header of libhal-lpc40, also
means that the version for this library must also be bumped.

Add default io_waiter to stream dacs