### PR TITLE
:recycle: Remove dma_initialize() function

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,4 @@ AllowShortFunctionsOnASingleLine: None
 FixNamespaceComments: true
 SpacesBeforeTrailingComments: 2
 ColumnLimit: 80
+QualifierAlignment: Right

--- a/include/libhal-lpc40/adc.hpp
+++ b/include/libhal-lpc40/adc.hpp
@@ -82,7 +82,7 @@ public:
    *
    * @param p_channel - Which adc channel to use
    */
-  adc(const channel& p_channel);
+  adc(channel const& p_channel);
 
   adc(adc const& p_other) = delete;
   adc& operator=(adc const& p_other) = delete;
@@ -94,6 +94,6 @@ private:
   channel get_predefined_channel_info(std::uint8_t p_channel);
   float driver_read() override;
 
-  volatile uint32_t* m_sample = nullptr;
+  uint32_t volatile* m_sample = nullptr;
 };
 }  // namespace hal::lpc40

--- a/include/libhal-lpc40/can.hpp
+++ b/include/libhal-lpc40/can.hpp
@@ -49,8 +49,8 @@ public:
     std::uint8_t tseg2 = 1;
   };
 
-  can(std::uint8_t p_port, const can::settings& p_settings = {});
-  can(const port& p_port, const can::settings& p_settings = {});
+  can(std::uint8_t p_port, can::settings const& p_settings = {});
+  can(port const& p_port, can::settings const& p_settings = {});
 
   can(can const& p_other) = delete;
   can& operator=(can const& p_other) = delete;
@@ -59,13 +59,13 @@ public:
   virtual ~can();
 
 private:
-  void driver_configure(const settings& p_settings) override;
+  void driver_configure(settings const& p_settings) override;
   void driver_bus_on() override;
-  void driver_send(const message_t& p_message) override;
+  void driver_send(message_t const& p_message) override;
 
-  void setup(const can::port& p_port, const can::settings& p_settings);
-  void configure_baud_rate(const can::port& p_port,
-                           const can::settings& p_settings);
+  void setup(can::port const& p_port, can::settings const& p_settings);
+  void configure_baud_rate(can::port const& p_port,
+                           can::settings const& p_settings);
   /**
    * @note This interrupt handler is used by both CAN1 and CAN2. This should
    *     only be called for a single CAN port to service both receive

--- a/include/libhal-lpc40/clock.hpp
+++ b/include/libhal-lpc40/clock.hpp
@@ -186,6 +186,6 @@ bool using_external_oscillator();
  *
  * TODO(#65): explain the set of errors in better detail
  */
-void configure_clocks(const clock_tree& p_clock_tree);
+void configure_clocks(clock_tree const& p_clock_tree);
 
 }  // namespace hal::lpc40

--- a/include/libhal-lpc40/dma.hpp
+++ b/include/libhal-lpc40/dma.hpp
@@ -82,10 +82,10 @@ enum class dma_peripheral : std::uint8_t
   uart2_rx_and_timer3_match1 = 15,
 };
 
-struct dma_configuration_t
+struct dma
 {
-  const volatile void* source;
-  volatile void* destination;
+  void const volatile* source;
+  void volatile* destination;
   std::size_t length;
   bool source_increment;
   bool destination_increment;
@@ -99,7 +99,6 @@ struct dma_configuration_t
   dma_burst_size destination_burst_size = dma_burst_size::bytes_1;
 };
 
-void initialize_dma();
-void setup_dma_transfer(const dma_configuration_t& p_configuration,
+void setup_dma_transfer(dma const& p_configuration,
                         hal::callback<void(void)> p_interrupt_callback);
 }  // namespace hal::lpc40

--- a/include/libhal-lpc40/i2c.hpp
+++ b/include/libhal-lpc40/i2c.hpp
@@ -36,7 +36,7 @@ namespace hal::lpc40 {
 class i2c final : public hal::i2c
 {
 public:
-  using write_iterator = std::span<const hal::byte>::iterator;
+  using write_iterator = std::span<hal::byte const>::iterator;
   using read_iterator = std::span<hal::byte>::iterator;
 
   /// port holds all of the information for an i2c bus on the LPC40xx
@@ -73,7 +73,7 @@ public:
    * is not 0, 1, or 2.
    */
   i2c(std::uint8_t p_bus,
-      const i2c::settings& p_settings = {},
+      i2c::settings const& p_settings = {},
       hal::io_waiter& p_waiter = hal::polling_io_waiter());
 
   /**
@@ -89,8 +89,8 @@ public:
    * @throws hal::operation_not_supported - if the settings or bus info
    * designation could not be achieved.
    */
-  i2c(const bus_info& p_bus_info,
-      const i2c::settings& p_settings = {},
+  i2c(bus_info const& p_bus_info,
+      i2c::settings const& p_settings = {},
       hal::io_waiter& p_waiter = hal::polling_io_waiter());
 
   i2c(i2c const& p_other) = delete;
@@ -100,10 +100,10 @@ public:
   virtual ~i2c();
 
 private:
-  void driver_configure(const settings& p_settings) override;
+  void driver_configure(settings const& p_settings) override;
   void driver_transaction(
     hal::byte p_address,
-    std::span<const hal::byte> p_data_out,
+    std::span<hal::byte const> p_data_out,
     std::span<hal::byte> p_data_in,
     hal::function_ref<hal::timeout_function> p_timeout) override;
   void setup_interrupt();

--- a/include/libhal-lpc40/input_pin.hpp
+++ b/include/libhal-lpc40/input_pin.hpp
@@ -35,7 +35,7 @@ public:
    */
   input_pin(std::uint8_t p_port,
             std::uint8_t p_pin,
-            const input_pin::settings& p_settings = {});
+            input_pin::settings const& p_settings = {});
 
   input_pin(input_pin const& p_other) = delete;
   input_pin& operator=(input_pin const& p_other) = delete;
@@ -44,7 +44,7 @@ public:
   virtual ~input_pin() = default;
 
 private:
-  void driver_configure(const settings& p_settings) override;
+  void driver_configure(settings const& p_settings) override;
   bool driver_level() override;
 
   uint8_t m_port{};

--- a/include/libhal-lpc40/interrupt_pin.hpp
+++ b/include/libhal-lpc40/interrupt_pin.hpp
@@ -35,7 +35,7 @@ public:
    */
   interrupt_pin(std::uint8_t port,  // NOLINT
                 std::uint8_t pin,
-                const settings& p_settings = {});
+                settings const& p_settings = {});
   interrupt_pin(interrupt_pin const& p_other) = delete;
   interrupt_pin& operator=(interrupt_pin const& p_other) = delete;
   interrupt_pin(interrupt_pin&& p_other) noexcept = delete;
@@ -43,7 +43,7 @@ public:
   virtual ~interrupt_pin();
 
 private:
-  void driver_configure(const settings& p_settings) override;
+  void driver_configure(settings const& p_settings) override;
   void driver_on_trigger(hal::callback<handler> p_callback) override;
 
   uint8_t m_port;

--- a/include/libhal-lpc40/output_pin.hpp
+++ b/include/libhal-lpc40/output_pin.hpp
@@ -35,7 +35,7 @@ public:
    */
   output_pin(std::uint8_t p_port,
              std::uint8_t p_pin,
-             const output_pin::settings& p_settings = {});
+             output_pin::settings const& p_settings = {});
 
   output_pin(output_pin const& p_other) = delete;
   output_pin& operator=(output_pin const& p_other) = delete;
@@ -44,7 +44,7 @@ public:
   virtual ~output_pin() = default;
 
 private:
-  void driver_configure(const settings& p_settings) override;
+  void driver_configure(settings const& p_settings) override;
   void driver_level(bool p_high) override;
   bool driver_level() override;
 

--- a/include/libhal-lpc40/pin.hpp
+++ b/include/libhal-lpc40/pin.hpp
@@ -50,7 +50,7 @@ public:
    * @param p_function_code - the pin function code
    * @return pin& - reference to this pin for chaining
    */
-  const pin& function(uint8_t p_function_code) const;
+  pin const& function(uint8_t p_function_code) const;
 
   /**
    * @brief Set the internal resistor connection for this pin
@@ -58,7 +58,7 @@ public:
    * @param p_resistor - resistor type
    * @return pin& - reference to this pin for chaining
    */
-  const pin& resistor(hal::pin_resistor p_resistor) const;
+  pin const& resistor(hal::pin_resistor p_resistor) const;
 
   /**
    * @brief Disable or enable hysteresis mode for this pin
@@ -66,7 +66,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& hysteresis(bool p_enable) const;
+  pin const& hysteresis(bool p_enable) const;
 
   /**
    * @brief invert the logic for this pin in input mode
@@ -74,7 +74,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& input_invert(bool p_enable) const;
+  pin const& input_invert(bool p_enable) const;
 
   /**
    * @brief enable analog mode for this pin (required for dac and adc drivers)
@@ -82,7 +82,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& analog(bool p_enable) const;
+  pin const& analog(bool p_enable) const;
 
   /**
    * @brief enable digital filtering (filter out noise on input lines)
@@ -90,7 +90,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& digital_filter(bool p_enable) const;
+  pin const& digital_filter(bool p_enable) const;
 
   /**
    * @brief Enable high speed mode for i2c pins
@@ -98,7 +98,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& highspeed_i2c(bool p_enable = true) const;
+  pin const& highspeed_i2c(bool p_enable = true) const;
 
   /**
    * @brief enable high slew rate for pin
@@ -106,7 +106,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& high_slew_rate(bool p_enable = true) const;
+  pin const& high_slew_rate(bool p_enable = true) const;
 
   /**
    * @brief enable high current drain for i2c lines
@@ -114,7 +114,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& i2c_high_current(bool p_enable = true) const;
+  pin const& i2c_high_current(bool p_enable = true) const;
 
   /**
    * @brief Make the pin open drain (required for the i2c driver)
@@ -122,7 +122,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& open_drain(bool p_enable = true) const;
+  pin const& open_drain(bool p_enable = true) const;
 
   /**
    * @brief Enable dac mode (required for the dac driver)
@@ -130,7 +130,7 @@ public:
    * @param p_enable - enable this mode, set to false to disable this mode
    * @return pin& - reference to this pin for chaining
    */
-  const pin& dac(bool p_enable = true) const;
+  pin const& dac(bool p_enable = true) const;
 
 private:
   std::uint8_t m_port{};

--- a/include/libhal-lpc40/spi.hpp
+++ b/include/libhal-lpc40/spi.hpp
@@ -53,7 +53,7 @@ public:
    * @throws hal::operation_not_supported - if the p_bus is not 0, 1, or 2 or if
    * the spi settings could not be achieved.
    */
-  spi(std::uint8_t p_bus, const spi::settings& p_settings = {});
+  spi(std::uint8_t p_bus, spi::settings const& p_settings = {});
   /**
    * @brief Construct a new spi object using bus info directly
    *
@@ -68,8 +68,8 @@ public:
   virtual ~spi();
 
 private:
-  void driver_configure(const settings& p_settings) override;
-  void driver_transfer(std::span<const hal::byte> p_data_out,
+  void driver_configure(settings const& p_settings) override;
+  void driver_transfer(std::span<hal::byte const> p_data_out,
                        std::span<hal::byte> p_data_in,
                        hal::byte p_filler) override;
 

--- a/include/libhal-lpc40/stream_dac.hpp
+++ b/include/libhal-lpc40/stream_dac.hpp
@@ -20,14 +20,14 @@ class stream_dac_u16 final : public hal::stream_dac_u16
 {
 public:
   stream_dac_u16(hal::io_waiter& p_waiter = hal::polling_io_waiter());
-  stream_dac_u16(const stream_dac_u16& p_other) = delete;
-  stream_dac_u16& operator=(const stream_dac_u16& p_other) = delete;
+  stream_dac_u16(stream_dac_u16 const& p_other) = delete;
+  stream_dac_u16& operator=(stream_dac_u16 const& p_other) = delete;
   stream_dac_u16(stream_dac_u16&& p_other) noexcept = delete;
   stream_dac_u16& operator=(stream_dac_u16&& p_other) noexcept = delete;
   virtual ~stream_dac_u16() = default;
 
 private:
-  void driver_write(const hal::stream_dac_u16::samples& p_samples) override;
+  void driver_write(hal::stream_dac_u16::samples const& p_samples) override;
 
   hal::io_waiter* m_waiter;
 };
@@ -50,14 +50,14 @@ class stream_dac_u8 final : public hal::stream_dac_u8
 {
 public:
   stream_dac_u8(hal::io_waiter& p_waiter = hal::polling_io_waiter());
-  stream_dac_u8(const stream_dac_u8& p_other) = delete;
-  stream_dac_u8& operator=(const stream_dac_u8& p_other) = delete;
+  stream_dac_u8(stream_dac_u8 const& p_other) = delete;
+  stream_dac_u8& operator=(stream_dac_u8 const& p_other) = delete;
   stream_dac_u8(stream_dac_u8&& p_other) noexcept = delete;
   stream_dac_u8& operator=(stream_dac_u8&& p_other) noexcept = delete;
   virtual ~stream_dac_u8() = default;
 
 private:
-  void driver_write(const hal::stream_dac_u8::samples& p_samples) override;
+  void driver_write(hal::stream_dac_u8::samples const& p_samples) override;
 
   hal::io_waiter* m_waiter;
 };

--- a/include/libhal-lpc40/uart.hpp
+++ b/include/libhal-lpc40/uart.hpp
@@ -59,7 +59,7 @@ public:
    */
   uart(std::uint8_t p_port_number,
        std::span<hal::byte> p_receive_working_buffer,
-       const serial::settings& p_settings = {});
+       serial::settings const& p_settings = {});
   /**
    * @brief Construct a new uart object
    *
@@ -67,9 +67,9 @@ public:
    * @param p_receive_working_buffer
    * @param p_settings
    */
-  uart(const uart::port& p_port,
+  uart(uart::port const& p_port,
        std::span<hal::byte> p_receive_working_buffer,
-       const serial::settings& p_settings = {});
+       serial::settings const& p_settings = {});
 
   uart(uart const& p_other) = delete;
   uart& operator=(uart const& p_other) = delete;
@@ -78,8 +78,8 @@ public:
   virtual ~uart() = default;
 
 private:
-  void driver_configure(const settings& p_settings) override;
-  write_t driver_write(std::span<const hal::byte> p_data) override;
+  void driver_configure(settings const& p_settings) override;
+  write_t driver_write(std::span<hal::byte const> p_data) override;
   read_t driver_read(std::span<hal::byte> p_data) override;
   void driver_flush() override;
 


### PR DESCRIPTION
Rather than have setup_dma_transfer have a precondition on calling dma_initialize(), setup_dma_transfer will now perform the work of initializing dma if it is not already initialized.

Initialization and setup of the dma resource is synchronized with an atomic_flag, preventing thread safety issues.