### PR TITLE
:thread: Add `set_dma_lock(hal::basic_lock&)` api

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,3 @@ FixNamespaceComments: true
 SpacesBeforeTrailingComments: 2
 ColumnLimit: 80
 QualifierAlignment: Right
-QualifierAlignment: Right

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: 🚀 Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cortex-m4_lpc4072_74:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      arch: cortex-m4
+      version: ${{ github.ref_name }}
+      os: baremetal
+      compiler: gcc
+      compiler_version: 12.3
+      compiler_package: arm-gnu-toolchain
+    secrets: inherit
+
+  cortex-m4f_lpc4076_78_88:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      arch: cortex-m4f
+      version: ${{ github.ref_name }}
+      os: baremetal
+      compiler: gcc
+      compiler_version: 12.3
+      compiler_package: arm-gnu-toolchain
+    secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,13 @@ libhal_test_and_make_library(
   libhal
   libhal-util
   libhal-armcortex
+  libhal-soft
   ring-span-lite
 
   LINK_LIBRARIES
   libhal::libhal
   libhal::util
   libhal::armcortex
+  libhal::soft
   nonstd::ring-span-lite
 )

--- a/conanfile.py
+++ b/conanfile.py
@@ -54,9 +54,10 @@ class libhal_lpc40_conan(ConanFile):
         bootstrap.module.add_library_requirements(
             self,
             override_libhal_util_version="5.0.1",
-            override_libhal_version="4.2.0")
+            override_libhal_version="4.3.0")
         self.requires("libhal-armcortex/[^5.0.1]", transitive_headers=True)
         self.requires("ring-span-lite/[^0.7.0]", transitive_headers=True)
+        self.requires("libhal-soft/[^5.1.0]")
 
     def add_linker_scripts_to_link_flags(self):
         platform = str(self.options.platform)

--- a/include/libhal-lpc40/dma.hpp
+++ b/include/libhal-lpc40/dma.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include <libhal/functional.hpp>
+#include <libhal/lock.hpp>
 
 namespace hal::lpc40 {
 
@@ -99,6 +100,26 @@ struct dma
   dma_burst_size destination_burst_size = dma_burst_size::bytes_1;
 };
 
+/**
+ * @brief Set the dma lock object
+ *
+ * This API is not thread safe and should be performed before dma is used
+ * between threads. The default dma lock object is a hal::atomic_spin_lock which
+ * is operating system agnostic but inefficient. If you are using an operating
+ * system, use this call to replace the original spin lock with the appropriate
+ * mutex.
+ *
+ * @param p_lock - basic lock to be used for locking dma across threads. Should
+ * be a OS safe mutex.
+ */
+void set_dma_lock(hal::basic_lock& p_lock);
+
+/**
+ * @brief Setup and start a dma transfer
+ *
+ * @param p_configuration - dma configuration
+ * @param p_interrupt_callback - callback when dma has completed
+ */
 void setup_dma_transfer(dma const& p_configuration,
                         hal::callback<void(void)> p_interrupt_callback);
 }  // namespace hal::lpc40


### PR DESCRIPTION
This API takes a basic lock and uses it to lock the dma between accesses. The default lock is a hal::atomic_spin_lock which is inefficient but system agnostic.